### PR TITLE
Updated link to documentation system

### DIFF
--- a/011-designdocs/01-morrita/index.html
+++ b/011-designdocs/01-morrita/index.html
@@ -114,7 +114,7 @@ Design docs が生まれた 15-20 年くらい前というのは agile movement 
 <h2 id="目についたよさげな事例たち">目についたよさげな事例たち</h2>
 <p>実際のところモダンテキストの試みはそれなりにある。</p>
 <p>特にオープンソース・コミュニティの成熟化にともない「解説」の方は割と充実してきている。
-ぱっと良い資料がみつからないけれど、たとえばこの <a href="https://documentation.divio.com/">The documentation system</a> によれば
+ぱっと良い資料がみつからないけれど、たとえばこの <a href="https://diataxis.fr/">The Diátaxis documentation system</a> によれば
 Tutorials, HOW-TO Guides, Explanation, Reference という軸があるとしている。なるほど。</p>
 <p>最近だと <a href="https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html">ARCHITECTURE.md というのを書くと良いよ</a>
 という話があって、これもなるほどなと思う。</p>


### PR DESCRIPTION
The canonical home of the documentation system is now https://diataxis.fr.